### PR TITLE
Fixed up syntax error in app.src file.

### DIFF
--- a/src/small_ints.app.src
+++ b/src/small_ints.app.src
@@ -10,5 +10,5 @@
   {modules, []},
   {contributors, ["Andrea Leopardi"]},
   {licenses, ["MIT"]},
-  {links, [{"GitHub", "https://github.com/whatyouhide/small_ints"}]},
+  {links, [{"GitHub", "https://github.com/whatyouhide/small_ints"}]}
  ]}.


### PR DESCRIPTION
The trailing "," was casuing a compile error when using the library in an Elixir project.
